### PR TITLE
feat: select PostgreSQL dump client by server version

### DIFF
--- a/app/backup-postgresql
+++ b/app/backup-postgresql
@@ -118,5 +118,6 @@ postgresql_databases:
   username: ${PGUSER}
   password: ${PGPASSWORD}
   hostname: ${HOSTNAME}
+  pg_dump_command: /usr/local/bin/pg_dumpall-for-server
 
 EOF


### PR DESCRIPTION
Generated Borgmatic PostgreSQL configuration now uses the exporter wrapper that selects the matching pg_dumpall client based on server_version_num.